### PR TITLE
Extend Ruby support to include class methods defined with self.

### DIFF
--- a/lib/supported-files.coffee
+++ b/lib/supported-files.coffee
@@ -63,8 +63,14 @@ class SupportedFiles
 
     'rb':
       regExp: ///
-        # matches 'def REPLACE'
-        def \s+ REPLACE
+        # matches 'def'
+        def \s+
+
+        # optionally matches 'self.'
+        (self\.)?
+
+        # match REPLACE
+        REPLACE
       ///
       isTabBased: true
 


### PR DESCRIPTION
This Atom plugin is great @DFreds, thanks for creating it! I do most of my work in Ruby so @goronfreeman's addition of Ruby support is much appreciated as well.

I have discovered that class methods defined with `self.` are not found so this PR adds `self.` as an optional matcher to the Ruby regex.

P.S. Special thanks to my teammates @Heath101 and @GawainReif for helping me nail down the regex.
