### PR TITLE
Hack in semanticolor compatibility

### DIFF
--- a/lib/text-editor-parser.coffee
+++ b/lib/text-editor-parser.coffee
@@ -20,7 +20,7 @@ class TextEditorParser
 
   getGrammarName: ->
     return null if not @textEditor?
-    return @textEditor.getGrammar().name
+    return @textEditor.getGrammar().name.replace("semanticolor - ", "")
 
   getWordContainingCursor: ->
     return null if not @textEditor?

--- a/spec/text-editor-parser-spec.coffee
+++ b/spec/text-editor-parser-spec.coffee
@@ -36,6 +36,15 @@ describe "TextEditorParser", ->
     it "should return the file type", ->
       expect(fileType).toEqual('js')
 
+  describe "when getting the grammar name", ->
+
+    it "should return the grammar name from the text editor", ->
+      spyOn(textEditor, 'getGrammar').andReturn({'name': 'Ruby'})
+      expect(textEditorParser.getGrammarName()).toEqual('Ruby')
+    it "should strip off semanticolor prefix if present", ->
+      spyOn(textEditor, 'getGrammar').andReturn({'name': 'semanticolor - Ruby'})
+      expect(textEditorParser.getGrammarName()).toEqual('Ruby')
+
   describe "when getting the word containing the cursor", ->
     word = null
 


### PR DESCRIPTION
Resolves #21 in a pretty hackish manner - just strips out the semanticolor - string from the grammar name. There may be other plugins that will need a similar fix. It may also make more sense for semanticolor to change the way they modify the grammar name, but this is a quick fix to allow people who use both plugins to get code peek working.